### PR TITLE
Fixed sorting due to async write of output

### DIFF
--- a/server.js
+++ b/server.js
@@ -59,17 +59,17 @@ app.get(`/${TOKEN}/:bucket_name`, (req, res, next) => {
 
         Promise.all(files_subset.map((filename) => {
             return readFileAsync(path.join(bucket_dir, filename)).then((content) => {
-                res.write("============ " + filename + " ============");
-                res.write("\n");
-
-                res.write(content);
-                res.write("\n");
-
-                res.write("=======================================================");
-                res.write("\n");
-                res.write("\n");
+                return [
+                    "============ " + filename + " ============",
+                    content,
+                    "=======================================================",
+                    "\n"
+                ].join("\n");
             });
-        })).then(() => res.end());
+        })).then((webhookLogs) => {
+            webhookLogs.forEach((log) => res.write(log));
+            res.end()
+        });
     });
 });
 


### PR DESCRIPTION
Your writing of the individual files into `res` was async and so the sorting of the files beforehand did not ensure the correct order of writes.

I fixed this by creating intermediate strings inside `Promise.all` and using the (now sorted) result in `Promise`'s `then`

Before:

```
~/W/webhookbin (master) $ curl http://localhost:8877/bda98695-b53e-4a63-a9c5-8b115ba6539c/asdf2
============ 2018-04-06T10:04:59.758Z.json ============
{
  "number": "2"
}
=======================================================

============ 2018-04-06T10:05:08.936Z.json ============
{
  "number": "5"
}
=======================================================

============ 2018-04-06T10:05:05.798Z.json ============
{
  "number": "4"
}
=======================================================

============ 2018-04-06T10:05:02.513Z.json ============
{
  "number": "3"
}
=======================================================

============ 2018-04-06T10:04:56.025Z.json ============
{
  "number": "1"
}
=======================================================
```

After:
```
~/W/webhookbin (master) $ curl http://localhost:8877/bda98695-b53e-4a63-a9c5-8b115ba6539c/asdf2
============ 2018-04-06T10:05:08.936Z.json ============
{
  "number": "5"
}
=======================================================

============ 2018-04-06T10:05:05.798Z.json ============
{
  "number": "4"
}
=======================================================

============ 2018-04-06T10:05:02.513Z.json ============
{
  "number": "3"
}
=======================================================

============ 2018-04-06T10:04:59.758Z.json ============
{
  "number": "2"
}
=======================================================

============ 2018-04-06T10:04:56.025Z.json ============
{
  "number": "1"
}
=======================================================
```